### PR TITLE
feat: support multiple GitHub repositories with array-based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ First, we need to set up an AWS IAM OIDC identity provider and an AWS IAM role t
 module "aws_federation_github_actions" {
   source = "github.com/rpidanny/aws-federation-github-actions?ref=v1.0.0"
 
-  github_org  = "rpidanny"
-  github_repo = "example-repo"
+  github_org   = "rpidanny"
+  github_repos = ["example-repo"]
 
   iam_role_name   = "ExampleGithubRole"
   iam_policy_arns = [data.aws_iam_policy.AdministratorAccess.arn]
@@ -26,11 +26,11 @@ module "aws_federation_github_actions" {
 }
 ```
 
-With this deployed, any jobs in `rpidanny/example-repo` can now assume the IAM Role created above.
+With this deployed, any jobs in the specified repositories can now assume the IAM Role created above.
 
-The `github_org` and `github_repo` ensures that only the repo you specify here can assume the role.
+The `github_org` and `github_repos` ensures that only the repositories you specify can assume the role.
 
-**Note:** If you don't pass in `github_repo`, any repo in your Github Organization will be able to assume the role. This is useful when you want to grant all your organization's repo access to aws.
+You can specify one or more repositories by adding them to the `github_repos` array. To grant access to all repositories in your organization, simply omit the `github_repos` parameter.
 
 ### Configure GitHub Actions Workflow
 
@@ -72,13 +72,13 @@ An example integration can be found here: [examples/dog_food](examples/dog_food)
 
 ## Module Inputs
 
-| Name              | Description                                                                                  | Type           | Default | Required |
-| ----------------- | -------------------------------------------------------------------------------------------- | -------------- | ------- | :------: |
-| `github_org`      | Name of the github organization you want to allow access to.                                 | `string`       | n/a     |   yes    |
-| `github_repo`     | Name of the github repo you want to allow access to. Default will grant access to all repos. | `string`       | `''`    |    no    |
-| `iam_role_name`   | Name of the IAM role you want to allow access to assume.                                     | `string`       | n/a     |   yes    |
-| `iam_policy_arns` | List of IAM policy ARNs that is attached to the IAM role.                                    | `list(string)` | `[]`    |    no    |
-| `tags`            | Resource tags.                                                                               | `map(string)`  | `{}`    |    no    |
+| Name              | Description                                                                                     | Type           | Default | Required |
+| ----------------- | ----------------------------------------------------------------------------------------------- | -------------- | ------- | :------: |
+| `github_org`      | Name of the github organization you want to allow access to.                                    | `string`       | n/a     |   yes    |
+| `github_repos`    | List of github repositories you want to allow access to. Empty list grants access to all repos. | `list(string)` | `[]`    |    no    |
+| `iam_role_name`   | Name to use when creating the IAM role that GitHub Actions can assume.                          | `string`       | n/a     |   yes    |
+| `iam_policy_arns` | List of IAM policy ARNs that is attached to the IAM role.                                       | `list(string)` | `[]`    |    no    |
+| `tags`            | Resource tags.                                                                                  | `map(string)`  | `{}`    |    no    |
 
 ## Module Outputs
 

--- a/examples/dog_food/main.tf
+++ b/examples/dog_food/main.tf
@@ -1,7 +1,8 @@
 module "aws_federation_github_actions" {
   source = "../../"
 
-  github_org = "rpidanny"
+  github_org   = "rpidanny"
+  github_repos = ["aws-federation-github-actions"]
 
   iam_role_name   = "automation-gha-ci"
   iam_policy_arns = [data.aws_iam_policy.AdministratorAccess.arn]

--- a/variables.tf
+++ b/variables.tf
@@ -3,15 +3,15 @@ variable "github_org" {
   description = "Name of the github organization you want to allow access to"
 }
 
-variable "github_repo" {
-  type        = string
-  description = "Name of the github repo you want to allow access to"
-  default     = ""
+variable "github_repos" {
+  type        = list(string)
+  description = "List of github repositories you want to allow access to"
+  default     = []
 }
 
 variable "iam_role_name" {
   type        = string
-  description = "Name of the IAM role you want to allow access to assume"
+  description = "Name to use when creating the IAM role that GitHub Actions can assume"
 }
 
 variable "iam_policy_arns" {


### PR DESCRIPTION
## Summary

This PR enhances the module to support multiple GitHub repositories through an array-based configuration, replacing the single repository approach.

## Changes

- **Breaking Change**: Replace `github_repo` (string) with `github_repos` (list of strings)
- **IAM Policy Enhancement**: Update IAM role policy to generate individual statements for each repository using Terraform's `for` expression
- **Fallback Support**: Add automatic fallback to allow all organization repositories when `github_repos` is empty
- **Documentation**: Simplify and clarify documentation with updated examples and variable descriptions
- **Example Update**: Update dog_food example to use new `github_repos` parameter

## Migration

Users need to update their configuration from:
```hcl
github_repo = "my-repo"
```

To:
```hcl
github_repos = ["my-repo"]
```

## Backward Compatibility

While this is a breaking change in terms of variable names, the functionality is enhanced:
- Single repo: `github_repos = ["repo1"]`
- Multiple repos: `github_repos = ["repo1", "repo2", "repo3"]`
- All repos: omit `github_repos` parameter (same as before)