### PR TITLE
fix: remove unnecessary npm cache from GitHub Actions

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -20,15 +20,6 @@ runs:
         persist-credentials: false
         fetch-depth: 1
 
-    - name: Cache node modules
-      uses: actions/cache@v2
-      id: npm-cache
-      with:
-        path: "${{ github.repository }}/**/node_modules"
-        key: npm-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          npm-
-
     - name: Setup nodejs
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
## Description

This PR removes the unnecessary npm cache step from the GitHub Actions release workflow.

## Changes

- Removed the `Cache node modules` step from `.github/actions/release/action.yml`
- This step was redundant as npm automatically handles caching in newer versions

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

- [x] Workflow changes have been tested
- [x] No breaking changes to existing functionality

## Conventional Commits

This PR follows conventional commits specification with the commit message:
`fix: remove unnecessary npm cache`